### PR TITLE
Added option to permit description text in report

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ the code pretty much anytime I make a change), you can alternatively
 
 This is a command-line tool, it takes some basic options.
 
-`wptreport [--input /path/to/dir] [--output /path/to/dir] [--spec SpecName]`
+`wptreport [--input /path/to/dir] [--output /path/to/dir] [--spec SpecName] [-f] [-m] [-d description]`
 
 * `--input <directory>`, `-i  <directory>`: Path to the directory that contains all the JSON data. 
   JSON files must match the pattern `\w{2}\d{d}\.json` where the two first letters are an identifier 
@@ -35,6 +35,9 @@ This is a command-line tool, it takes some basic options.
   Defaults to the current directory.
 * `--spec SpecName`, `-s SpecName`: The specification name to use in titling the report. Optional, 
   but certainly looks nicer.
+* `--description DescFile`, `-d DescFile`: Include a description of report at the top.
+* `--failures`, `-f`: Include messages about failures in report.
+* `--markdown`, `-m`: Interpret subtest names as markdown.
 * `--help`, `-h`: Get some help (about the tool, you're on your own for your other issues).
 * `--version`, `-v`: Get the version number.
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ var fs = require("fs-extra")
                 ,   spec:       String
                 ,   version:    Boolean
                 ,   markdown:   Boolean
+                ,   description:String
                 ,   failures:   Boolean
                 }
 ,   shortHands = {
@@ -31,6 +32,7 @@ var fs = require("fs-extra")
                 ,   s:      ["--spec"]
                 ,   v:      ["--version"]
                 ,   m:      ["--markdown"]
+                ,   d:      ["--description"]
                 ,   f:      ["--failures"]
                 }
 ,   parsed = nopt(knownOpts, shortHands)
@@ -42,6 +44,7 @@ var fs = require("fs-extra")
     ,   spec:       parsed.spec || ""
     ,   failures:   parsed.failures || false
     ,   markdown:   parsed.markdown || false
+    ,   description:parsed.description || ""
     }
 ,   prefix = options.spec ? options.spec + ": " : ""
 ,   out = {
@@ -126,6 +129,7 @@ if (options.help) {
     ,   "                directory."
     ,   "   --failures, -f to include any failure message text"
     ,   "   --markdown, -m to interpret subtest name as Markdown"
+    ,   "   --description, -d description file to use to annotation the report."
     ,   "   --spec, -s SpecName to use in titling the report."
     ,   "   --help, -h to produce this message."
     ,   "   --version, -v to show the version number."
@@ -261,6 +265,7 @@ for (var test in out.results) {
 var startTable = "<thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>" + out.ua.join("</th><th>") + "</th></tr></thead>\n"
 ,   startToc = "<h3>Test Files</h3>\n<ol class='toc'>"
 ,   script = options.failures ? "window.setTimeout(function() { \n $('.message_toggle').show();\n$('.message_toggle').on('click', function() {\n$('.messages').toggle();\n});\n}, 1000);" : ""
+,   description = (options.description !== "") ? rfs(jn(options.input, options.description)) : ""
 ;
 
 
@@ -299,6 +304,7 @@ var startTable = "<thead><tr class='persist-header'><th>Test <span class='messag
         ,   meta:  meta
         ,   toc:  toc
         ,   script: script
+        ,   desc:   description
         })
     );
 }());
@@ -344,6 +350,7 @@ var startTable = "<thead><tr class='persist-header'><th>Test <span class='messag
         ,   meta:  meta
         ,   toc:  toc
         ,   script: script
+        ,   desc:   description
         })
     );
 }());
@@ -390,6 +397,7 @@ var startTable = "<thead><tr class='persist-header'><th>Test <span class='messag
         ,   meta:  meta
         ,   toc:  toc
         ,   script: script
+        ,   desc:   description
         })
     );
 }());

--- a/res/template.html
+++ b/res/template.html
@@ -11,6 +11,7 @@
       <header>
         <h1>{{title}}</h1>
       </header>
+      {{desc}}
       {{meta}}
       {{toc}}
       <table class='table persist-area'>


### PR DESCRIPTION
So a group can elect to augment the report with extra text to explain
the notations etc.

See test-results/annotation-model/all.html for an example.