### PR TITLE
Added processing for message comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,6 +209,11 @@ for (var agent in consolidated) {
         // if there is a message, then capture it so we can include it in the output
         if (testData.hasOwnProperty("message") && testData.message !== null) {
             out.results[id].UAmessage[agent] = testData.message;
+            if (testData.message.match(/NOTRUN:/)) {
+                testData.status = "NOTRUN";
+            } else if (testData.message.match(/SKIPPED:/)) {
+                testData.status = "NOTRUN";
+            }
         }
         out.results[id].byUA[agent] = testData.status;
         if (!out.results[id].totals[testData.status]) out.results[id].totals[testData.status] = 1;
@@ -234,7 +239,15 @@ for (var agent in consolidated) {
                 ;
                 if (filter.excludeCase(id, stName)) continue;
                 if (stName === "constructor") stName = "_constructor";
+                // if the message has a comment with a special result, use that to decide what to do
+                if (st.message && st.message.match(/NOTRUN:/)) {
+                    continue;
+                } else if (st.message && st.message.match(/SKIPPED:/)) {
+                    continue;
+                }
+
                 if (!out.results[id].subtests[stName]) out.results[id].subtests[stName] = { stNum: j, byUA: {}, UAmessage: {}, totals: {} };
+
                 out.results[id].subtests[stName].byUA[agent] = st.status;
                 if (!out.results[id].subtests[stName].totals[st.status]) out.results[id].subtests[stName].totals[st.status] = 1;
                 else out.results[id].subtests[stName].totals[st.status]++;


### PR DESCRIPTION
If a message comment on a test or a subtest contains the string
"NOTRUN:" or "SKIPPED:" then the result of the test or subtest is
not used nor reported in the overall calculations. Useful for subtests
that are not run on some platforms (e.g., when an A11Y Technology API
does not support some minor aspect of an overall feature.

Note that the result of a test case will never be PASS if all of the
subtests are skipped.  In that case the result of the test will be
NOTRUN.