### PR TITLE
Remove extra semicolon that breaks package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
         "test",
         "tests",
         "results",
-        "wpt",
+        "wpt"
     ]
 }


### PR DESCRIPTION
This fixes error when running "npm link ." after cloning this repo.